### PR TITLE
 Add new config option for sending an `already formatted record`

### DIFF
--- a/fluent-plugin-raygun.gemspec
+++ b/fluent-plugin-raygun.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "fluent-plugin-raygun"
-  spec.version       = "0.0.1"
+  spec.version       = "0.0.2"
   spec.authors       = ["Taylor Lodge"]
   spec.email         = ["taylor@raygun.io"]
   spec.summary       = %q{Fluentd output plugin that sends aggregated errors/exception events to Raygun. Raygun is a error logging and aggregation platform.}

--- a/lib/fluent/plugin/out_raygun.rb
+++ b/lib/fluent/plugin/out_raygun.rb
@@ -82,6 +82,6 @@ class Fluent::RaygunOutput < Fluent::BufferedOutput
     )
     post.body = JSON.generate(payload)
 
-    response = @http.request(@uri, post)
+    @http.request(@uri, post)
   end
 end

--- a/lib/fluent/plugin/out_raygun.rb
+++ b/lib/fluent/plugin/out_raygun.rb
@@ -3,16 +3,16 @@ class Fluent::RaygunOutput < Fluent::BufferedOutput
 
   include Fluent::HandleTagNameMixin
 
-  LOG_LEVEL = %w(fatal error warning info debug)
-  EVENT_KEYS = %w(message timestamp time_spent level logger culprit server_name release tags)
-  DEFAULT_HOSTNAME_COMMAND = 'hostname'
+  LOG_LEVEL = %w[fatal error warning info debug].freeze
+  EVENT_KEYS = %w[message timestamp time_spent level logger culprit server_name release tags].freeze
+  DEFAULT_HOSTNAME_COMMAND = 'hostname'.freeze
 
-  config_param :default_level, :string, :default => 'error'
-  config_param :default_logger, :string, :default => 'fluentd'
-  config_param :endpoint_url, :string, :default => 'https://api.raygun.com'
+  config_param :default_level, :string, default: 'error'
+  config_param :default_logger, :string, default: 'fluentd'
+  config_param :endpoint_url, :string, default: 'https://api.raygun.com'
   config_param :api_key, :string
-  config_param :flush_interval, :time, :default => 0
-  config_param :hostname_command, :string, :default => 'hostname'
+  config_param :flush_interval, :time, default: 0
+  config_param :hostname_command, :string, default: 'hostname'
 
   def initialize
     require 'time'
@@ -48,7 +48,7 @@ class Fluent::RaygunOutput < Fluent::BufferedOutput
     @http.idle_timeout = 10
     @http.socket_options << [Socket::SOL_SOCKET, Socket::SO_KEEPALIVE, 1]
 
-    log.debug "Started Raygun fluent shipper.."
+    log.debug 'Started Raygun fluent shipper..'
   end
 
   def format(tag, time, record)
@@ -63,8 +63,8 @@ class Fluent::RaygunOutput < Fluent::BufferedOutput
     chunk.msgpack_each do |tag, time, record|
       begin
         notify_raygun(tag, time, record)
-      rescue => e
-        $log.error("Raygun Error:", :error_class => e.class, :error => e.message)
+      rescue StandardError => e
+        $log.error('Raygun Error:', error_class: e.class, error: e.message)
       end
     end
   end
@@ -73,16 +73,16 @@ class Fluent::RaygunOutput < Fluent::BufferedOutput
     payload = {
       occurredOn: Time.at(time).utc.iso8601,
       details: {
-	machineName: @hostname,
+        machineName: @hostname,
         error: {
-	  message: record['messages']
-	},
-	tags: [tag],
+          message: record['messages']
+        },
+        tags: [tag]
       }
     }
 
     post = Net::HTTP::Post.new(
-      "#{@endpoint_url}/entries?apikey=#{URI::encode(@api_key)}",
+      "#{@endpoint_url}/entries?apikey=#{URI.encode(@api_key)}"
     )
     post.body = JSON.generate(payload)
 

--- a/lib/fluent/plugin/out_raygun.rb
+++ b/lib/fluent/plugin/out_raygun.rb
@@ -55,10 +55,6 @@ class Fluent::RaygunOutput < Fluent::BufferedOutput
     [tag, time, record].to_msgpack
   end
 
-  def shutdown
-    super
-  end
-
   def write(chunk)
     chunk.msgpack_each do |tag, time, record|
       begin


### PR DESCRIPTION
The method `notify_raygun` used to have:

...
  payload = {
      occurredOn: Time.at(time).utc.iso8601,
      details: {
        machineName: @hostname,
        error: {
          message: record['messages']
        },
        tags: [tag]
      }
    }
...

because the default logging record from fluentd is
a collection of messages with the key "messages":

...
`https://www.fluentd.org/datasources/rails`

2014-07-07 19:39:01 +0000 foo: {"messages":"{"meth...
...

However there could be times when the record hits this
fluent output plugin and the record/payload is already
in the desired format.

So I've added the `already formatted record` flag/config
to simply pass the record on directly as the payload.

For example I've already shaped the incoming record
to meet one of Rayguns APIs
https://raygun.com/docs/integrations/api
and I don't want it changed.